### PR TITLE
fix: manifest.json for dxt

### DIFF
--- a/build-dxt.sh
+++ b/build-dxt.sh
@@ -127,9 +127,6 @@ cat > dist/opendia-dxt/manifest.json << 'EOF'
   "license": "MIT", 
   "keywords": ["browser", "automation", "mcp", "ai", "claude", "chrome", "firefox", "extension", "twitter", "linkedin", "facebook", "anti-detection"],
   "icon": "icon.png",
-  "icons": {
-    "128": "icon.png"
-  },
   
   "server": {
     "type": "node",
@@ -153,16 +150,16 @@ cat > dist/opendia-dxt/manifest.json << 'EOF'
       "title": "WebSocket Port",
       "description": "Port for Chrome/Firefox extension connection",
       "default": 5555,
-      "minimum": 1024,
-      "maximum": 65535
+      "min": 1024,
+      "max": 65535
     },
     "http_port": {
       "type": "number",
       "title": "HTTP Port", 
       "description": "Port for HTTP/SSE server",
       "default": 5556,
-      "minimum": 1024,
-      "maximum": 65535
+      "min": 1024,
+      "max": 65535
     },
     "enable_tunnel": {
       "type": "boolean",
@@ -251,30 +248,7 @@ cat > dist/opendia-dxt/manifest.json << 'EOF'
       "name": "page_style",
       "description": "🎨 Transform page appearance with themes and effects"
     }
-  ],
-  
-  "capabilities": {
-    "browser_automation": true,
-    "anti_detection": true,
-    "background_tabs": true,
-    "multi_tab_workflows": true,
-    "content_extraction": true,
-    "form_filling": true,
-    "social_media_posting": true,
-    "page_styling": true,
-    "bookmark_management": true,
-    "history_search": true,
-    "tab_management": true
-  },
-  
-  "requirements": {
-    "browser_extension": {
-      "name": "OpenDia Browser Extension",
-      "description": "Required Chrome/Firefox extension for browser automation by Aaron Elijah Mars",
-      "version": "1.1.0",
-      "auto_install": false
-    }
-  }
+  ]
 }
 EOF
 


### PR DESCRIPTION
Hi! This PR fixes the manifest.json and removes keys that keep us from adding it to our Claude directory.

```
dxt pack .
Validating manifest...
ERROR: Manifest validation failed:

  - user_config.ws_port: Unrecognized key(s) in object: 'minimum', 'maximum'
  - user_config.http_port: Unrecognized key(s) in object: 'minimum', 'maximum'
  - Unrecognized key(s) in object: 'icons', 'capabilities', 'requirements'
ERROR: Cannot pack extension with invalid manifest
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Simplified the manifest by removing capability and requirement sections.
  * Updated port configuration keys for consistency.
  * Streamlined icon specification in the manifest.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->