### PR TITLE
fix(mcp): stop double-wrapping JSON-RPC responses on SSE POST

### DIFF
--- a/opendia-mcp/server.js
+++ b/opendia-mcp/server.js
@@ -1656,18 +1656,21 @@ app.route('/sse')
   .post(async (req, res) => {
     // MCP requests from online AI
     console.error('MCP request received via SSE:', req.body);
-    
+
     try {
-      const result = await handleMCPRequest(req.body);
-      res.json({
-        jsonrpc: "2.0",
-        id: req.body.id,
-        result: result
-      });
+      // handleMCPRequest already returns a complete JSON-RPC response
+      // (or null for notifications) — forward as-is, matching the stdio path.
+      const response = await handleMCPRequest(req.body);
+      if (response === null) {
+        // JSON-RPC notification: no response body per spec
+        res.status(204).end();
+      } else {
+        res.json(response);
+      }
     } catch (error) {
       res.status(500).json({
         jsonrpc: "2.0",
-        id: req.body.id,
+        id: req.body?.id ?? null,
         error: { code: -32603, message: error.message }
       });
     }


### PR DESCRIPTION
## Summary
The `/sse` POST handler in `opendia-mcp/server.js` was wrapping `handleMCPRequest`'s return value inside a second JSON-RPC envelope, breaking online-AI / SSE clients (Cursor, ChatGPT-via-tunnel). Forward the response as-is, matching the stdio path.

## Changes
- `opendia-mcp/server.js` — `/sse` POST handler now sends `handleMCPRequest`'s response directly. Returns `204 No Content` for JSON-RPC notifications (where `handleMCPRequest` returns `null`) per spec. Made the catch-block id lookup defensive against malformed bodies.

## Context
`handleMCPRequest` already returns a complete JSON-RPC response — `{ jsonrpc, id, result }` on success, `{ jsonrpc, id, error }` on internal failure, or `null` for notifications. The stdio path (`process.stdin.on('data', ...)`) writes that directly. The SSE POST path was instead doing:

```js
const result = await handleMCPRequest(req.body);
res.json({ jsonrpc: "2.0", id: req.body.id, result: result });
```

So an SSE client requesting `tools/list` would receive:

```json
{
  "jsonrpc": "2.0",
  "id": 1,
  "result": { "jsonrpc": "2.0", "id": 1, "result": { "tools": [...] } }
}
```

…and any internal error from `handleMCPRequest` came back as `result.error` instead of top-level `error`, so the client never saw it as a failure. Notifications (which return `null`) were also being echoed as `result: null`, which is invalid for a non-notification response.

After the fix, SSE responses match the stdio responses byte-for-byte.

---
Built by [Aeon](https://github.com/aaronjmars/aeon-aaron)