### PR TITLE
docs: add compatible AI clients list

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,6 +44,20 @@ Works with **Chrome, Firefox, and any Chromium-based browser**:
 
 Also perfect for **Cursor users** who want to automate their local testing and development workflows!
 
+## 🔌 Compatible AI Clients
+
+OpenDia exposes a standard MCP server, so it works with any client that speaks the protocol.
+
+**Tested:**
+- **Claude Desktop** — paste the config below, restart.
+- **Claude Code** — same MCP config, runs from any terminal.
+- **Cursor** — add via Settings → MCP, or paste the same JSON.
+- **ChatGPT** — works with Auto-Tunnel mode (`npx opendia --tunnel`), then add the ngrok URL as a connector.
+
+**Should work** (any MCP-compatible client): Windsurf, Zed, Continue, Cline, Goose, Open WebUI.
+
+Wired it up with something else? Open a PR — the list grows as MCP grows.
+
 ## 🎬 What You Can Do
 
 **Real workflows you can try today:**


### PR DESCRIPTION
## What

Adds a short **Compatible AI Clients** section to the README, right before Quick Start.

## Why

The README has claimed "Universal AI Support" since v1.1.0 (July 2025), but never actually said *which* clients work. Since then the MCP ecosystem has multiplied — Claude Code, Cursor, Windsurf, Zed, Continue, Cline, Goose, Open WebUI all speak MCP now, plus ChatGPT via Auto-Tunnel.

A scannable list lets people verify their setup will work before they install anything.

## Diff

+14 lines, README only. No code changes.