### PR TITLE
fix(mcp): guard extension reconnect against stale close events

### DIFF
--- a/opendia-mcp/server.js
+++ b/opendia-mcp/server.js
@@ -1565,6 +1565,17 @@ function handleToolResponse(message) {
 // Setup WebSocket connection handlers
 function setupWebSocketHandlers() {
   wss.on("connection", (ws) => {
+    // If an old extension socket is still tracked, close it before replacing
+    // so the previous connection's close handler can't later null out the new one.
+    if (chromeExtensionSocket && chromeExtensionSocket !== ws) {
+      console.error("Replacing existing Browser Extension connection");
+      try {
+        chromeExtensionSocket.close();
+      } catch (e) {
+        // ignore — socket may already be half-closed
+      }
+    }
+
     console.error("Browser Extension connected");
     chromeExtensionSocket = ws;
 
@@ -1602,10 +1613,18 @@ function setupWebSocketHandlers() {
     });
 
     ws.on("close", () => {
-      console.error("Browser Extension disconnected");
-      chromeExtensionSocket = null;
-      availableTools = []; // Clear tools when extension disconnects
       clearInterval(pingInterval);
+      // Only clear tracked state if THIS socket is still the active one.
+      // Without this guard, a stale close event from a previous connection
+      // can null out a freshly reconnected extension and make the server
+      // falsely report "extension not connected" until the user restarts.
+      if (chromeExtensionSocket === ws) {
+        console.error("Browser Extension disconnected");
+        chromeExtensionSocket = null;
+        availableTools = []; // Clear tools when extension disconnects
+      } else {
+        console.error("Stale Browser Extension socket closed (already replaced)");
+      }
     });
 
     ws.on("error", (error) => {


### PR DESCRIPTION
## Summary
Fix a reconnect race in the extension WebSocket handler that makes the server falsely report "extension not connected" after a Chrome/Firefox reload.

## The bug
When the browser extension reconnects (Chrome reload, extension toggle, network blip), TCP timing can make the old socket's `close` event fire **after** the new socket's `connection` event. Today's flow:

1. New connection arrives → `chromeExtensionSocket = ws_new`
2. Old socket finally closes → `chromeExtensionSocket = null` (kills the live connection)
3. `tools/call` returns `Browser Extension not connected`
4. User restarts everything to recover.

## Changes
`opendia-mcp/server.js`:
- **On new connection**, if a previous socket is still tracked, close it before overwriting. Forces its close handler to run while it is still the active socket so the new one stays clean.
- **In the close handler**, only null `chromeExtensionSocket` / clear `availableTools` if the closing socket *is* the active one. Stale closes log a debug line and no-op. `clearInterval(pingInterval)` always runs so the ping timer does not leak.

Both changes are local to `setupWebSocketHandlers()`. No API surface changes, no new deps.

## Context
Spotted while reading the WS reconnect path. Same shape as classic event-listener identity bugs — comparing closures, not references. Easy to repro by toggling the extension on/off a few times: today you eventually need to restart the server, after this you do not.

---
Built by [Aeon](https://github.com/aaronjmars/aeon-aaron)