### PR TITLE
fix(mcp): use resolved HTTP_PORT in tunnel-mode local URL hint

### DIFF
--- a/opendia-mcp/server.js
+++ b/opendia-mcp/server.js
@@ -1862,7 +1862,7 @@ async function startServer() {
         console.error('💡 Claude Web: Add as external MCP server (if supported)');
         console.error('');
         console.error('🏠 Local access still available:');
-        console.error('🔗 http://localhost:3001/sse');
+        console.error(`🔗 http://localhost:${HTTP_PORT}/sse`);
         console.error('');
         
         // Store ngrok process for cleanup


### PR DESCRIPTION
## Summary
Tunnel-mode startup logs were pointing users to `http://localhost:3001/sse` for local access, but the default HTTP port migrated to `5556` long ago (see comment at `server.js:24`). Anyone following the on-screen URL hit a closed port.

## Changes
- `opendia-mcp/server.js:1865` — replace the hard-coded `localhost:3001` with the resolved `${HTTP_PORT}` so the local-access hint matches the port the server is actually bound to (and matches the non-tunnel branch a few lines below at `:1888`).

## Context
Spotted while reading `startServer()` end-to-end. Bug only fires under `--tunnel`, which is the path the README documents for ChatGPT users, so it's exactly the surface most likely to confuse new users:

```
🎉 OPENDIA READY!
📋 Copy this URL for online AI services:
🔗 https://<ngrok>.ngrok-free.app/sse

🏠 Local access still available:
🔗 http://localhost:3001/sse        ← wrong, nothing listens here
```

`node --check opendia-mcp/server.js` clean. No tests in the repo to update.

---
Built by [Aeon](https://github.com/aaronjmars/aeon-aaron)
