### PR TITLE
fix(mcp): guarantee unique call ids for concurrent tool calls

### DIFF
--- a/opendia-mcp/server.js
+++ b/opendia-mcp/server.js
@@ -153,6 +153,8 @@ let availableTools = [];
 
 // Tool call tracking
 const pendingCalls = new Map();
+// Monotonic counter so concurrent tool calls can never share a call id.
+let callIdCounter = 0;
 
 // Simple MCP protocol implementation over stdio
 async function handleMCPRequest(request) {
@@ -1526,7 +1528,11 @@ async function callBrowserTool(toolName, args) {
     );
   }
 
-  const callId = Date.now().toString();
+  // Date.now() alone collides when two calls fire in the same millisecond
+  // (concurrent SSE POSTs, hybrid stdio+SSE, or parallel tool calls). A
+  // collision overwrites the pending resolver, cross-wiring one call's
+  // response onto another and leaving the loser to hit the 30s timeout.
+  const callId = `${Date.now()}-${++callIdCounter}`;
 
   return new Promise((resolve, reject) => {
     pendingCalls.set(callId, { resolve, reject });


### PR DESCRIPTION
## Summary
Tool call ids in the MCP server were generated with `Date.now().toString()`, which collides when two calls fire in the same millisecond. On collision the second call overwrites the first's entry in `pendingCalls`, so the extension's response cross-wires onto the wrong promise and the losing call hangs until its 30s timeout.

## Changes
- `opendia-mcp/server.js` — add a monotonic `callIdCounter` and build the call id as `` `${Date.now()}-${++callIdCounter}` `` so concurrent calls can never share an id.

## Context
This collision is reachable in normal operation, not a theoretical edge case:
- Express handles `/sse` POST requests concurrently — two MCP `tools/call` POSTs arriving together collide.
- Hybrid mode runs stdio + SSE side by side.
- AI clients (Claude, ChatGPT) routinely issue parallel tool calls.

The symptom is nasty and hard to diagnose: one tool returns another tool's result, and the other call mysteriously times out after 30s. The extension treats the id as opaque and echoes it back verbatim (`background.js` `handleMCPRequest`), so changing the id format is safe. `node --check` passes.

---
Built by [Aeon](https://github.com/aaronjmars/aeon-aaron)
