### PR TITLE
fix(firefox): set background persistent:true so heartbeat/reconnect actually fire

### DIFF
--- a/opendia-extension/manifest-firefox.json
+++ b/opendia-extension/manifest-firefox.json
@@ -32,7 +32,7 @@
       "src/polyfill/browser-polyfill.min.js",
       "src/background/background.js"
     ],
-    "persistent": false
+    "persistent": true
   },
   "browser_action": {
     "default_popup": "src/popup/popup.html",


### PR DESCRIPTION
## Summary
`manifest-firefox.json` had `"persistent": false`, which lets Firefox suspend the background script after a short idle period — once suspended, the 15s `setInterval` heartbeat and the exponential-backoff reconnect scheduler in `src/background/background.js` stop firing, so a WebSocket drop leaves the extension in "Extension not connected" until the user reloads.

## Changes
- `opendia-extension/manifest-firefox.json` — `persistent: false` → `persistent: true`

## Context
Closes #29. The Firefox MV2 branch of `ConnectionManager` is built around a persistent background page: `setupHeartbeat` and `scheduleReconnect` both use `setInterval` and are explicitly gated on `!this.isServiceWorker`. With `persistent: false`, that whole branch was unreachable — same symptom users hit in #17 and #23 on the Firefox side. Setting `persistent: true` makes the existing reconnect path actually execute. Chrome MV3 (`manifest-chrome.json`) is unaffected — service workers don't take a `persistent` flag and continue to follow the temporary-connection path.

---
Built by [Aeon](https://github.com/aaronjmars/aeon-aaron)
