### PR TITLE
fix(mcp): reject pending tool calls when Browser Extension disconnects

### DIFF
--- a/opendia-mcp/server.js
+++ b/opendia-mcp/server.js
@@ -1535,7 +1535,17 @@ async function callBrowserTool(toolName, args) {
   const callId = `${Date.now()}-${++callIdCounter}`;
 
   return new Promise((resolve, reject) => {
-    pendingCalls.set(callId, { resolve, reject });
+    // Track the timeout on the pending entry so it can be cleared when a
+    // response arrives or the extension disconnects — otherwise every call
+    // leaks a 30s timer until it fires.
+    const timeout = setTimeout(() => {
+      if (pendingCalls.has(callId)) {
+        pendingCalls.delete(callId);
+        reject(new Error("Tool call timeout"));
+      }
+    }, 30000);
+
+    pendingCalls.set(callId, { resolve, reject, timeout });
 
     chromeExtensionSocket.send(
       JSON.stringify({
@@ -1544,14 +1554,6 @@ async function callBrowserTool(toolName, args) {
         params: args,
       })
     );
-
-    // Timeout after 30 seconds
-    setTimeout(() => {
-      if (pendingCalls.has(callId)) {
-        pendingCalls.delete(callId);
-        reject(new Error("Tool call timeout"));
-      }
-    }, 30000);
   });
 }
 
@@ -1559,6 +1561,7 @@ async function callBrowserTool(toolName, args) {
 function handleToolResponse(message) {
   const pending = pendingCalls.get(message.id);
   if (pending) {
+    clearTimeout(pending.timeout);
     pendingCalls.delete(message.id);
     if (message.error) {
       pending.reject(new Error(message.error.message));
@@ -1628,6 +1631,21 @@ function setupWebSocketHandlers() {
         console.error("Browser Extension disconnected");
         chromeExtensionSocket = null;
         availableTools = []; // Clear tools when extension disconnects
+        // Reject any in-flight tool calls immediately so the MCP client
+        // sees a real error instead of hanging for up to 30s waiting on
+        // a socket that's gone.
+        if (pendingCalls.size > 0) {
+          console.error(
+            `Rejecting ${pendingCalls.size} in-flight tool call(s) due to extension disconnect`
+          );
+          for (const pending of pendingCalls.values()) {
+            clearTimeout(pending.timeout);
+            pending.reject(
+              new Error("Browser Extension disconnected mid-call")
+            );
+          }
+          pendingCalls.clear();
+        }
       } else {
         console.error("Stale Browser Extension socket closed (already replaced)");
       }


### PR DESCRIPTION
## Summary

When the extension's WebSocket closed mid-call, every in-flight tool call was left dangling in `pendingCalls` until its 30s timeout fired — so the MCP client (Claude Desktop, Cursor, etc.) would hang for up to 30 seconds after an extension disconnect before getting an error. This fix rejects in-flight calls immediately on socket close, and also clears the timeout when a response arrives instead of leaving every successful call's 30s timer running until it fires.

## Changes

`opendia-mcp/server.js` (+27 / -9):

- `callBrowserTool` — track the 30s timeout on the pending entry (`{ resolve, reject, timeout }`) instead of leaving an unreferenced `setTimeout` running.
- `handleToolResponse` — `clearTimeout(pending.timeout)` so successful (and errored) calls don't leak a timer until it fires against an already-deleted `callId`.
- `ws.on('close')` — when the active extension socket closes, iterate `pendingCalls`, clear each timer, reject each with `\"Browser Extension disconnected mid-call\"`, and `pendingCalls.clear()`. Only runs in the existing `chromeExtensionSocket === ws` branch, so stale close events (the case PR #26 guarded) still no-op.

## Context

Extends the recent fix(mcp) call-lifecycle lane:

- #26 — guard extension reconnect against stale close events
- #28 — guarantee unique call ids for concurrent tool calls
- this — finish the call-lifecycle cleanup so disconnect doesn't strand callers waiting on the 30s timeout

Same surface, same naming pattern. No behaviour change on the happy path (callers still see resolve/reject normally); the change only affects (a) the timer that previously fired uselessly after every call, and (b) the dangling 30s wait after extension disconnect.

\`node --check opendia-mcp/server.js\` clean.

---
Built by [Aeon](https://github.com/aaronjmars/aeon-aaron)