### PR TITLE
chore: add CI workflow for MCP server and browser extension

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,47 @@
+name: CI
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+
+jobs:
+  mcp:
+    name: MCP server
+    runs-on: ubuntu-latest
+    defaults:
+      run:
+        working-directory: opendia-mcp
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 20
+          cache: npm
+          cache-dependency-path: opendia-mcp/package-lock.json
+      - run: npm ci
+      - name: Syntax-check server
+        run: node --check server.js
+
+  extension:
+    name: Browser extension
+    runs-on: ubuntu-latest
+    defaults:
+      run:
+        working-directory: opendia-extension
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 20
+          cache: npm
+          cache-dependency-path: opendia-extension/package-lock.json
+      - run: npm ci
+      - name: Build Chrome + Firefox
+        run: npm run build
+      - name: Validate builds
+        run: node build.js validate
+      - name: Structure tests
+        run: node test-extension.js
+      - name: Lint Firefox build (web-ext)
+        run: npx web-ext lint --source-dir=dist/firefox --self-hosted


### PR DESCRIPTION
## Summary
Adds a CI workflow (`.github/workflows/ci.yml`) so every push to `main` and every PR gets the MCP server and the browser extension built and checked automatically — opendia had no CI until now.

## Changes
- **`.github/workflows/ci.yml`** — two jobs on `push` (main) and `pull_request`:
  - **MCP server** (`opendia-mcp/`): `npm ci` + `node --check server.js`
  - **Browser extension** (`opendia-extension/`): `npm ci`, `npm run build` (Chrome MV3 + Firefox MV2), `node build.js validate`, `node test-extension.js`, and `web-ext lint` on the Firefox build.

Both jobs use `actions/setup-node@v4` with npm caching scoped to each package's lockfile.

## Context
opendia was flagged `MISSING_CI` — no automated checks guarded the build. The extension already ships a `build.js validate` step and a `test-extension.js` structure check; this wires them into CI alongside `web-ext lint`, the canonical web-extension linter (`web-ext` is already a devDependency). The lint targets the Firefox build only — `web-ext` is a Firefox/AMO tool and reports false-positive errors against the Chrome MV3 manifest.

All steps were run locally against the current tree and pass (`node --check` OK; build + validate + structure tests green; Firefox `web-ext lint` → 0 errors).

---
Built by [Aeon](https://github.com/aaronjmars/aeon)