### PR TITLE
chore: add Dependabot config for npm + GitHub Actions

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,43 @@
+version: 2
+updates:
+  # MCP server (Node.js)
+  - package-ecosystem: npm
+    directory: /opendia-mcp
+    schedule:
+      interval: weekly
+    open-pull-requests-limit: 5
+    commit-message:
+      prefix: chore(mcp-deps)
+    groups:
+      mcp-minor-and-patch:
+        update-types:
+          - minor
+          - patch
+
+  # Browser extension (Node.js)
+  - package-ecosystem: npm
+    directory: /opendia-extension
+    schedule:
+      interval: weekly
+    open-pull-requests-limit: 5
+    commit-message:
+      prefix: chore(ext-deps)
+    groups:
+      ext-minor-and-patch:
+        update-types:
+          - minor
+          - patch
+
+  # GitHub Actions used by the CI workflow
+  - package-ecosystem: github-actions
+    directory: /
+    schedule:
+      interval: weekly
+    open-pull-requests-limit: 5
+    commit-message:
+      prefix: chore(ci-deps)
+    groups:
+      actions-minor-and-patch:
+        update-types:
+          - minor
+          - patch


### PR DESCRIPTION
## Summary
Adds `.github/dependabot.yml` so dependency and GitHub Actions updates are proposed automatically. The repo had no Dependabot config, so npm deps in both packages and the CI Actions only move when bumped by hand.

## Changes
- `.github/dependabot.yml` — three update streams, all **weekly**:
  - `npm` in `/opendia-mcp` (express, cors, ws)
  - `npm` in `/opendia-extension` (webextension-polyfill, web-ext, fs-extra)
  - `github-actions` in `/` (the `actions/checkout` + `actions/setup-node` used by `ci.yml`)
- Minor/patch updates are **grouped per ecosystem** to keep PR volume low; majors still open individually so breaking bumps get reviewed on their own. `open-pull-requests-limit: 5` per stream.
- Commit prefixes scoped (`chore(mcp-deps)`, `chore(ext-deps)`, `chore(ci-deps)`) to match the repo's conventional-commit style.

## Context
Proactive supply-chain hygiene for the flagship (1.8k★, 146 forks). Config-only — no source or CI changes, so it can't break the build. As a bonus it will surface the `actions/checkout@v4` / `actions/setup-node@v4` major bumps that CI currently emits Node-20 deprecation notices for.

---
Built by [Aeon](https://github.com/aaronjmars)
