### PR TITLE
chore: npm auto-publish (provenance) + sync version to 1.1.1

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,0 +1,22 @@
+name: publish
+on:
+  push:
+    tags: ["v*"]
+permissions:
+  contents: read
+  id-token: write
+jobs:
+  publish:
+    runs-on: ubuntu-latest
+    defaults:
+      run:
+        working-directory: opendia-mcp
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 20
+          registry-url: https://registry.npmjs.org
+      - run: npm publish --provenance --access public
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}

--- a/opendia-mcp/package.json
+++ b/opendia-mcp/package.json
@@ -1,6 +1,6 @@
 {
   "name": "opendia",
-  "version": "1.1.0",
+  "version": "1.1.1",
   "description": "🎯 OpenDia - The open alternative to Dia. Connect your browser to AI models with anti-detection bypass for Twitter/X, LinkedIn, Facebook",
   "main": "server.js",
   "bin": {


### PR DESCRIPTION
Adds a tag-triggered `npm publish --provenance` workflow (verified 'Built and signed on GitHub Actions' badge on npmjs). Release future versions with: `npm version <patch|minor|major> && git push --follow-tags`. The NPM_TOKEN repo secret is set.