### PR TITLE
fix(deps): resolve all 8 Dependabot alerts (node-forge, brace-expansion)

### DIFF
--- a/opendia-extension/package-lock.json
+++ b/opendia-extension/package-lock.json
@@ -805,9 +805,9 @@
       }
     },
     "node_modules/brace-expansion": {
-      "version": "1.1.12",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.12.tgz",
-      "integrity": "sha512-9T9UjW3r0UW5c1Q7GTwllptXwhvYmEzFhzMfZ9H7FQWt+uZePjZPjBP/W1ZEyZ1twGWom5/56TF4lPcqjnDHcg==",
+      "version": "1.1.15",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.15.tgz",
+      "integrity": "sha512-EwOCDEex4quD37XhqM3omwtMoJjr//isUZz1JopUNWms+4Z2ViyM/k1YIRePpoVNnQhENnxtFjLaxNHrT7xIUg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -2708,9 +2708,9 @@
       "license": "MIT"
     },
     "node_modules/node-forge": {
-      "version": "1.3.1",
-      "resolved": "https://registry.npmjs.org/node-forge/-/node-forge-1.3.1.tgz",
-      "integrity": "sha512-dPEtOeMvF9VMcYV/1Wb8CPoVAXtp6MKMlcbAt4ddqmGqUJ6fQZFXkNZNkNlfevtNkGtaSoXf/vNNNSvgrdXwtA==",
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/node-forge/-/node-forge-1.4.0.tgz",
+      "integrity": "sha512-LarFH0+6VfriEhqMMcLX2F7SwSXeWwnEAJEsYm5QKWchiVYVvJyV9v7UDvUv+w5HO23ZpQTXDv/GxdDdMyOuoQ==",
       "dev": true,
       "license": "(BSD-3-Clause OR GPL-2.0)",
       "engines": {


### PR DESCRIPTION
Resolves all **8 open/dismissed Dependabot alerts** on the repo. Both vulnerable packages are transitive **dev** dependencies pulled in by \`web-ext\` (extension build/packaging tool), so nothing ships in the extension itself — but both bumps are within existing semver ranges, making this a safe lockfile-only change.

## Changes (`opendia-extension/package-lock.json`)
- `node-forge` **1.3.1 → 1.4.0** — clears alerts #1–#7
- `brace-expansion` **1.1.12 → 1.1.15** — clears alert #8

## Alerts resolved
| # | Sev | Package | Issue |
|---|-----|---------|-------|
| 7 | High | node-forge | basicConstraints bypass in cert chain verification |
| 6 | High | node-forge | Ed25519 signature forgery (missing S > L check) |
| 5 | High | node-forge | RSA-PKCS signature forgery (ASN.1 extra field) |
| 4 | High | node-forge | DoS via infinite loop in `modInverse()` |
| 3 | High | node-forge | ASN.1 Unbounded Recursion |
| 1 | High | node-forge | ASN.1 Validator Desynchronization |
| 2 | Medium | node-forge | ASN.1 OID Integer Truncation |
| 8 | Medium | brace-expansion | Zero-step sequence → process hang / memory exhaustion |

## Dependency chains
- `web-ext → @devicefarmer/adbkit → node-forge`
- `web-ext → … → minimatch → brace-expansion`

## Verification
- `npm audit` → **0 vulnerabilities**
- Lockfile-only diff (6 insertions / 6 deletions), no `package.json` changes