### PR TITLE
chore: update attribution to aeonfun / Aeon Inc

### DIFF
--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -32,7 +32,7 @@ both and landing a PR.
 **Prerequisites:** Node.js 20+.
 
 ```bash
-git clone https://github.com/aaronjmars/opendia.git && cd opendia
+git clone https://github.com/aeonfun/opendia.git && cd opendia
 
 # 1. Start the MCP server
 cd opendia-mcp

--- a/.github/README.md
+++ b/.github/README.md
@@ -6,7 +6,7 @@ No browser switching needed—works seamlessly with Chrome, Firefox, and any Chr
 If you are not technical / never used MCPs before, we recommend using **[Perplexity Comet](https://pplx.ai/leosimon)**.
 
 [![npm version](https://img.shields.io/npm/v/opendia)](https://www.npmjs.com/package/opendia)
-[![GitHub release](https://img.shields.io/github/release/aaronjmars/opendia.svg)](https://github.com/aaronjmars/opendia/releases/latest)
+[![GitHub release](https://img.shields.io/github/release/aeonfun/opendia.svg)](https://github.com/aeonfun/opendia/releases/latest)
 [![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](https://opensource.org/licenses/MIT)
 
 ## 📺 See it in Action
@@ -98,14 +98,14 @@ Wired it up with something else? Open a PR — the list grows as MCP grows.
 ### 1. Install the Browser Extension
 
 **For Chrome/Chromium browsers:**
-1. Download `opendia-chrome-1.1.0.zip` from [releases](https://github.com/aaronjmars/opendia/releases)
+1. Download `opendia-chrome-1.1.0.zip` from [releases](https://github.com/aeonfun/opendia/releases)
 2. Extract the zip file to a folder
 3. Go to `chrome://extensions/` (or your browser's extension page)
 4. Enable "Developer mode"
 5. Click "Load unpacked" and select the extracted folder
 
 **For Firefox:**
-1. Download `opendia-firefox-1.1.0.zip` from [releases](https://github.com/aaronjmars/opendia/releases)
+1. Download `opendia-firefox-1.1.0.zip` from [releases](https://github.com/aeonfun/opendia/releases)
 2. Extract the zip file to a folder
 3. Go to `about:debugging#/runtime/this-firefox`
 4. Click "Load Temporary Add-on..."
@@ -116,7 +116,7 @@ Wired it up with something else? Open a PR — the list grows as MCP grows.
 ### 2. Connect to Your AI
 
 **Option 1: Double-click Installation (Recommended)**
-1. Download the `opendia.dxt` file from [releases](https://github.com/aaronjmars/opendia/releases)
+1. Download the `opendia.dxt` file from [releases](https://github.com/aeonfun/opendia/releases)
 2. Double-click the `.dxt` file to install automatically
 3. The MCP will be added to your Claude Desktop configuration
 
@@ -292,7 +292,7 @@ Love to have your help making OpenDia better!
 
 ### Quick Development Setup
 ```bash
-git clone https://github.com/aaronjmars/opendia.git
+git clone https://github.com/aeonfun/opendia.git
 cd opendia
 
 # Start the server
@@ -307,7 +307,7 @@ npm start
 ```
 
 ### Ways to Contribute
-- 🐛 **Report bugs** via [GitHub Issues](https://github.com/aaronjmars/opendia/issues)
+- 🐛 **Report bugs** via [GitHub Issues](https://github.com/aeonfun/opendia/issues)
 - 💡 **Share it on social medias**
 - 🔧 **Add new browser capabilities** 
 - 📖 **Improve documentation**

--- a/.github/SECURITY.md
+++ b/.github/SECURITY.md
@@ -13,7 +13,7 @@ problem privately.
 **Please don't open a public issue for a security problem.** Use GitHub's
 **Private Vulnerability Reporting (PVR)** instead:
 
-➡️ **[Report a vulnerability](https://github.com/aaronjmars/opendia/security/advisories/new)**
+➡️ **[Report a vulnerability](https://github.com/aeonfun/opendia/security/advisories/new)**
 
 (Repo → **Security** tab → **Report a vulnerability**.) This opens a private
 advisory that only the maintainers can see — never a public issue, so a fix can
@@ -46,7 +46,7 @@ rather stay anonymous.
 ## Supported versions
 
 Security fixes land on the `main` branch of
-[`aaronjmars/opendia`](https://github.com/aaronjmars/opendia) and the latest
+[`aeonfun/opendia`](https://github.com/aeonfun/opendia) and the latest
 published [`opendia`](https://www.npmjs.com/package/opendia) npm release + extension
 build.
 

--- a/LICENSE
+++ b/LICENSE
@@ -1,6 +1,6 @@
 MIT License
 
-Copyright (c) 2025 OpenDia Team
+Copyright (c) 2025 Aeon Inc
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/build-dxt.sh
+++ b/build-dxt.sh
@@ -55,7 +55,7 @@ cat > dist/opendia-dxt/package.json << 'EOF'
     "anti-detection",
     "dxt"
   ],
-  "author": "Aaron Elijah Mars <aeonfun@proton.me>",
+  "author": "Aeon Inc",
   "license": "MIT",
   "dependencies": {
     "cors": "^2.8.5",
@@ -119,8 +119,7 @@ cat > dist/opendia-dxt/manifest.json << 'EOF'
   "version": "1.1.0",
   "description": "🎯 OpenDia - The open alternative to Dia. Connect your browser to AI models with anti-detection bypass for Twitter/X, LinkedIn, Facebook + universal automation",
   "author": {
-    "name": "Aaron Elijah Mars",
-    "email": "aeonfun@proton.me",
+    "name": "Aeon Inc",
     "url": "https://github.com/aeonfun/opendia"
   },
   "homepage": "https://github.com/aeonfun/opendia",

--- a/build-dxt.sh
+++ b/build-dxt.sh
@@ -55,7 +55,7 @@ cat > dist/opendia-dxt/package.json << 'EOF'
     "anti-detection",
     "dxt"
   ],
-  "author": "Aaron Elijah Mars <aaronjmars@proton.me>",
+  "author": "Aaron Elijah Mars <aeonfun@proton.me>",
   "license": "MIT",
   "dependencies": {
     "cors": "^2.8.5",
@@ -120,10 +120,10 @@ cat > dist/opendia-dxt/manifest.json << 'EOF'
   "description": "🎯 OpenDia - The open alternative to Dia. Connect your browser to AI models with anti-detection bypass for Twitter/X, LinkedIn, Facebook + universal automation",
   "author": {
     "name": "Aaron Elijah Mars",
-    "email": "aaronjmars@proton.me",
-    "url": "https://github.com/aaronjmars/opendia"
+    "email": "aeonfun@proton.me",
+    "url": "https://github.com/aeonfun/opendia"
   },
-  "homepage": "https://github.com/aaronjmars/opendia",
+  "homepage": "https://github.com/aeonfun/opendia",
   "license": "MIT", 
   "keywords": ["browser", "automation", "mcp", "ai", "claude", "chrome", "firefox", "extension", "twitter", "linkedin", "facebook", "anti-detection"],
   "icon": "icon.png",
@@ -269,7 +269,7 @@ cp LICENSE dist/opendia-dxt/ 2>/dev/null || echo "⚠️  LICENSE not found, ski
 cat > dist/opendia-dxt/EXTENSION_INSTALL.md << 'EOF'
 # OpenDia Browser Extension Installation
 
-**🔗 Official Repository:** https://github.com/aaronjmars/opendia
+**🔗 Official Repository:** https://github.com/aeonfun/opendia
 
 ## Complete Installation Guide
 
@@ -279,7 +279,7 @@ cat > dist/opendia-dxt/EXTENSION_INSTALL.md << 'EOF'
 ### Step 2: Install Browser Extension
 
 **📦 Get Latest Extension:**
-Download the latest extension from: https://github.com/aaronjmars/opendia/releases
+Download the latest extension from: https://github.com/aeonfun/opendia/releases
 
 **Or use the included extension in this DXT package:**
 
@@ -330,9 +330,9 @@ Download the latest extension from: https://github.com/aaronjmars/opendia/releas
 
 ## Getting Help
 
-- **📖 Full Documentation:** https://github.com/aaronjmars/opendia
-- **🐛 Report Issues:** https://github.com/aaronjmars/opendia/issues
-- **💬 Discussions:** https://github.com/aaronjmars/opendia/discussions
+- **📖 Full Documentation:** https://github.com/aeonfun/opendia
+- **🐛 Report Issues:** https://github.com/aeonfun/opendia/issues
+- **💬 Discussions:** https://github.com/aeonfun/opendia/discussions
 
 ## What's Next?
 

--- a/opendia-extension/package.json
+++ b/opendia-extension/package.json
@@ -16,7 +16,7 @@
     "mcp",
     "browser-automation"
   ],
-  "author": "Aaron J Mars",
+  "author": "Aeon Inc",
   "license": "MIT",
   "dependencies": {
     "webextension-polyfill": "^0.12.0"

--- a/opendia-mcp/README.md
+++ b/opendia-mcp/README.md
@@ -77,7 +77,7 @@ npx opendia
 ```
 
 ### 2. Install the Browser Extension
-1. Download from [releases](https://github.com/aaronjmars/opendia/releases)
+1. Download from [releases](https://github.com/aeonfun/opendia/releases)
 2. Go to `chrome://extensions/` (or your browser's extension page)
 3. Enable "Developer mode"
 4. Click "Load unpacked" and select the extension folder
@@ -180,7 +180,7 @@ Love to have your help making OpenDia better!
 
 ### Quick Development Setup
 ```bash
-git clone https://github.com/aaronjmars/opendia.git
+git clone https://github.com/aeonfun/opendia.git
 cd opendia
 
 # Start the server
@@ -193,7 +193,7 @@ npm start
 ```
 
 ### Ways to Contribute
-- 🐛 **Report bugs** via [GitHub Issues](https://github.com/aaronjmars/opendia/issues)
+- 🐛 **Report bugs** via [GitHub Issues](https://github.com/aeonfun/opendia/issues)
 - 💡 **Share it on social medias**
 - 🔧 **Add new browser capabilities** 
 - 📖 **Improve documentation**

--- a/opendia-mcp/package.json
+++ b/opendia-mcp/package.json
@@ -26,15 +26,15 @@
     "facebook",
     "anti-detection"
   ],
-  "author": "OpenDia Team",
+  "author": "Aeon Inc",
   "license": "MIT",
   "repository": {
     "type": "git",
-    "url": "https://github.com/aaronjmars/opendia.git"
+    "url": "https://github.com/aeonfun/opendia.git"
   },
-  "homepage": "https://github.com/aaronjmars/opendia",
+  "homepage": "https://github.com/aeonfun/opendia",
   "bugs": {
-    "url": "https://github.com/aaronjmars/opendia/issues"
+    "url": "https://github.com/aeonfun/opendia/issues"
   },
   "dependencies": {
     "cors": "^2.8.5",


### PR DESCRIPTION
Repo was transferred from `aaronjmars` to the `aeonfun` org (owned by **Aeon Inc**). This updates all self-referential GitHub links, badges, clone URLs, package.json metadata (repository/homepage/bugs), and LICENSE/author attribution.

**Preserved intentionally:** the published Firefox add-on ID `opendia@aaronjmars.com` (changing it breaks extension updates for existing users).