### PR TITLE
build(deps): override adm-zip to ^0.6.0 to clear GHSA-xcpc-8h2w-3j85

### DIFF
--- a/opendia-extension/package-lock.json
+++ b/opendia-extension/package-lock.json
@@ -577,13 +577,13 @@
       }
     },
     "node_modules/adm-zip": {
-      "version": "0.5.16",
-      "resolved": "https://registry.npmjs.org/adm-zip/-/adm-zip-0.5.16.tgz",
-      "integrity": "sha512-TGw5yVi4saajsSEgz25grObGHEUaDrniwvA2qwSC060KfqGPdglhvPMA2lPIoxs3PQIItj2iag35fONcQqgUaQ==",
+      "version": "0.6.0",
+      "resolved": "https://registry.npmjs.org/adm-zip/-/adm-zip-0.6.0.tgz",
+      "integrity": "sha512-XleryMhbuksdKtofnWZ9Sk+4CUTbms4Mb/EU32SZwToAyZ5RgVos/ki8n+yr0LWHOGKuakbXTuuYNHLQjhddgg==",
       "dev": true,
       "license": "MIT",
       "engines": {
-        "node": ">=12.0"
+        "node": ">=14.0"
       }
     },
     "node_modules/agent-base": {

--- a/opendia-extension/package.json
+++ b/opendia-extension/package.json
@@ -24,5 +24,8 @@
   "devDependencies": {
     "fs-extra": "^11.3.6",
     "web-ext": "^10.5.0"
+  },
+  "overrides": {
+    "adm-zip": "^0.6.0"
   }
 }


### PR DESCRIPTION
Dependabot alert #9 (high): a crafted ZIP makes adm-zip < 0.6.0 allocate 4GB.
The extension resolved adm-zip 0.5.16 transitively.

Dependabot could not open a PR because there is no upstream fix to bump to:

  web-ext@10.5.0 (latest)
    └─ firefox-profile@4.7.0 (latest)
         └─ adm-zip "~0.5.x"   ← cannot reach the patched 0.6.0

The range is pinned to 0.5.x, so the only way to take the patch today is an
override. Reachability is narrow either way — adm-zip is devDependencies-only
and never ships in dist/, and of firefox-profile's two call sites only
addExtension() parses an untrusted archive (`new AdmZip(xpi)`), which needs
`web-ext run` with a hostile .xpi. CI only runs `web-ext lint`. So this is
hygiene, not an incident.

Verified with npm 10 (CI is Node 20) that the override resolves and the
dependent still works:

  npm ci                        adm-zip 0.6.0
  firefox_profile.encoded()     OK, zip roundtrip readable
  addExtension(.xpi)            OK (the AdmZip(path)+extractAllTo path)
  npm run build                 OK
  node build.js validate        OK, chrome + firefox
  node test-extension.js        OK
  web-ext lint                  exit 0, 0 errors (3 pre-existing warnings)

Drop the override once firefox-profile widens its range.

Co-Authored-By: Claude <noreply@anthropic.com>